### PR TITLE
feat: enable s3 sse default encryption

### DIFF
--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -1721,6 +1721,7 @@ Resources:
   S3KmsKey:
     Type: AWS::KMS::Key
     Properties:
+      EnableKeyRotation: true
       KeyPolicy:
         Version: "2012-10-17"
         Statement:
@@ -1730,6 +1731,23 @@ Resources:
             Principal:
               AWS:
                 - Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              StringEquals:
+                kms:CallerAccount:
+                  Ref: AWS::AccountId
+                kms:ViaService:
+                  Fn::Sub: s3.${AWS::Region}.amazonaws.com
 
   SentryBucket:
     Type: AWS::S3::Bucket

--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -1755,7 +1755,8 @@ Resources:
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
-        - ServerSideEncryptionByDefault:
+        - BucketKeyEnabled: true
+          ServerSideEncryptionByDefault:
             SSEAlgorithm: 'aws:kms'
             KMSMasterKeyID:
               Fn::GetAtt: S3KmsKey.Arn

--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -1718,10 +1718,29 @@ Resources:
       SecretString:
         Ref: SentryEmailPassword
 
+  S3KmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: kms:*
+            Resource: "*"
+            Principal:
+              AWS:
+                - Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+
   SentryBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: 'aws:kms'
+            KMSMasterKeyID:
+              Fn::GetAtt: S3KmsKey.Arn
       PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         BlockPublicPolicy: True
@@ -5720,10 +5739,3 @@ Resources:
                 print(str(e))
                 data["Reason"] = str(e)
                 cfnresponse.send(event, context, cfnresponse.FAILED, data)
-
-
-
-
-
-
-


### PR DESCRIPTION
This MR enables default encryption with a KMS key for the S3 bucket as discussed in https://github.com/Rungutan/sentry-fargate-cf-stack/issues/17.

