### PR TITLE
feat: support ecs execute-command to open a shell in a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ In order to correctly perform the migration, you would have to:
   * Create a bastion host in the desired VPC public subnet. Make sure to use a instance type with enough CPU/Mem/Network bandwidth because the dump can be quite huge on large instances.
   * The bastion host's security group needs to be added to the `Ec2SecurityGroup` as allowed inbound traffic
   * Login to this bastion host. Make sure that `pgsql` and `pv` are installed. 
-    * See [https://techviewleo.com/install-postgresql-12-on-amazon-linux/](here) how to install pgsql 12 on Amazon Linux 2
-    * To install `pv` you have to [https://aws.amazon.com/de/premiumsupport/knowledge-center/ec2-enable-epel/](enable the EPEL) repository.
+    * See [here](https://techviewleo.com/install-postgresql-12-on-amazon-linux/) how to install pgsql 12 on Amazon Linux 2
+    * To install `pv` you have to [enable the EPEL](https://aws.amazon.com/de/premiumsupport/knowledge-center/ec2-enable-epel/) repository.
   * Make a database backup (see [utilities/dump.sh](utilities/dump.sh) script)
   * Run the CloudFormation stack update
   * Import the database dump (see [utilities/import.sh](utilities/import.sh) script)
@@ -290,7 +290,7 @@ In order to correctly perform the migration, you would have to:
 
 ### Using a private ECR Docker image mirror
 
-Since Docker hub has started to enforce API limits for public repos, you may end up in a situation where images cannot be fetched from the public Docker repo. You can set up your own mirror as a private ECR repository and change parameters for the Docker images accordingly. [https://github.com/seatgeek/docker-mirror](Docker-Mirror) can help you in automating the mirroring process.
+Since Docker hub has started to enforce API limits for public repos, you may end up in a situation where images cannot be fetched from the public Docker repo. You can set up your own mirror as a private ECR repository and change parameters for the Docker images accordingly. [Docker-Mirror](https://github.com/seatgeek/docker-mirror) can help you in automating the mirroring process.
 
 #### Example config
 
@@ -320,9 +320,33 @@ repositories:
     max_tag_age: 4w
 ```
 
-####mExample image parameters
+#### Example image parameters
 ```
 ACCOUNTID.dkr.ecr.REGION.amazonaws.com/hub/rungutancommunity/bash:1.13.2
+```
+
+### Connecting to a ECS Fargate container using aws cli exec-command
+
+There is a new [feature](https://aws.amazon.com/de/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/) that allows you to connect directly into a container. This can help greatly during debugging or running `snuba` commands for example.
+
+#### Example command to launch a shell in a specific container
+
+```bash
+export AWS_PROFILE=profilename
+export AWS_REGION=eu-central-1
+export ECS_CLUSTER=sentry-ClusterWorkers-xxx123
+export ECS_TASK=taskid
+export ECS_CONTAINER=sentry-snuba-sessions-consumer
+
+aws ecs execute-command --region $AWS_REGION --cluster $ECS_CLUSTER --task $ECS_TASK --container $ECS_CONTAINER --command "/bin/bash" --interactive
+
+
+The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
+
+
+Starting session with SessionId: ecs-execute-command-1234567890
+root@ip-172-80-12-34:/usr/src/snuba# 
+
 ```
 
 ## Final thoughts

--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -2259,6 +2259,13 @@ Resources:
                 - s3:CreateJob
                 - s3:HeadBucket
               Resource: "*"
+            - Effect: Allow
+              Action:
+                - ssmmessages:CreateControlChannel
+                - ssmmessages:CreateDataChannel
+                - ssmmessages:OpenControlChannel
+                - ssmmessages:OpenDataChannel
+              Resource: "*"
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -2396,6 +2403,7 @@ Resources:
           ContainerPort: 1218
           TargetGroupArn:
             Ref: TargetGroupSnubaApi
+      EnableExecuteCommand: true
 
   TargetGroupSnubaApi:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -2664,6 +2672,7 @@ Resources:
           ContainerPort: 9000
           TargetGroupArn:
             Ref: TargetGroupSentryWeb
+      EnableExecuteCommand: true            
 
   TargetGroupSentryWeb:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -2929,6 +2938,7 @@ Resources:
           ContainerPort: 3000
           TargetGroupArn:
             Ref: TargetGroupRelay
+      EnableExecuteCommand: true
 
   TargetGroupRelay:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -3215,6 +3225,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   TaskDefinitionSentryIngestAttachments:
     Type: AWS::ECS::TaskDefinition
@@ -3383,6 +3394,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSentryIngestAttachments:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -3597,6 +3609,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSentryIngestEvents:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -3811,6 +3824,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSentryIngestTransactions:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4025,6 +4039,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSentryPostProcessForward:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4192,6 +4207,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSnubaSessionsConsumer:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4359,6 +4375,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSnubaEventsConsumer:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4526,6 +4543,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSnubaOutcomesConsumer:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4693,6 +4711,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSnubaTransactionsConsumer:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -4861,6 +4880,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSnubaEventsReplacer:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
@@ -5071,6 +5091,7 @@ Resources:
             - Ref: PrivateSubnet3
           SecurityGroups:
             - Ref: Ec2SecurityGroup
+      EnableExecuteCommand: true
 
   AutoScalingTargetSentryWorkers:
     Type: AWS::ApplicationAutoScaling::ScalableTarget


### PR DESCRIPTION
This PR adds support for the newly introduced `ecs execute-command` that allows you to open a shell inside a container. I used this to issue `snuba migrations` commands that helped me to mitigate https://github.com/Rungutan/sentry-fargate-cf-stack/issues/49