### PR TITLE
fix: remove duplicate mapping entry

### DIFF
--- a/cloudformation-template.yaml
+++ b/cloudformation-template.yaml
@@ -613,8 +613,6 @@ Mappings:
       ScaleValue: 2500
     db.r5.12xlarge:
       ScaleValue: 2500
-    db.r5.12xlarge:
-      ScaleValue: 2500
 
 Resources:
 


### PR DESCRIPTION
duplicate entry breaking the cloudfromation. AWS cloudformation designer unable to parse the cloudformation with this bug